### PR TITLE
occidentalis 0.6.0:  apt repo migration; occi CLI tweaks

### DIFF
--- a/packages/occidentalis/DEBIAN/changelog
+++ b/packages/occidentalis/DEBIAN/changelog
@@ -1,3 +1,10 @@
+occidentalis (0.6.0) unstable; urgency=low
+
+  * migrates apt repository to apt.adafruit.com
+  * bumps occi version dependency to add flags
+
+ -- Brennen Bearnes <bbearnes@gmail.com>  Mon, 02 Feb 2015 14:09:23 -0700
+
 occidentalis (0.5.7) unstable; urgency=low
 
   * bumps suggested webide version 

--- a/packages/occidentalis/DEBIAN/control
+++ b/packages/occidentalis/DEBIAN/control
@@ -1,9 +1,9 @@
 Package: occidentalis
-Version: 0.5.7
+Version: 0.6.0
 Section: base
 Priority: optional
 Architecture: armhf
-Depends: avahi-daemon (>= 0.6.31), netatalk (>= 2.2.2), node (>= 0.10.35), occi (>= 0.5.0), tmux (>= 1.6-2), i2c-tools, python-smbus, vim, git, samba, samba-common-bin
+Depends: avahi-daemon (>= 0.6.31), netatalk (>= 2.2.2), node (>= 0.10.35), occi (>= 0.5.1), tmux (>= 1.6-2), i2c-tools, python-smbus, vim, git, samba, samba-common-bin
 Suggests: adafruitwebide (>= 0.3.10)
 Maintainer: Todd Treece <todd@uniontownlabs.org>
 Description: Occidentalis

--- a/packages/occidentalis/DEBIAN/postinst
+++ b/packages/occidentalis/DEBIAN/postinst
@@ -38,7 +38,10 @@ fi
 # Migrate from apt.uniontownlabs.org to apt.adafruit.com
 if grep -q 'apt.uniontownlabs.org' /etc/apt/sources.list; then
   echo "Migrating to apt.adafruit.com from apt.uniontownlabs.org"
-  sed -i '/apt.uniontownlabs.org/apt.adafruit.com/d' /etc/apt/sources.list
-  echo "deb http://apt.adafruit.com/raspbian/ wheezy main" >> /etc/apt/sources.list
+  sed -i '/apt.uniontownlabs.org/d' /etc/apt/sources.list
+
+  if ! grep -q 'apt.adafruit.com' /etc/apt/sources.list; then
+    echo "deb http://apt.adafruit.com/raspbian/ wheezy main" >> /etc/apt/sources.list
+  fi
   wget -O - -q https://apt.adafruit.com/apt.adafruit.com.gpg.key | apt-key add -
 fi

--- a/packages/occidentalis/DEBIAN/postinst
+++ b/packages/occidentalis/DEBIAN/postinst
@@ -38,6 +38,7 @@ fi
 # Migrate from apt.uniontownlabs.org to apt.adafruit.com
 if grep -q 'apt.uniontownlabs.org' /etc/apt/sources.list; then
   echo "Migrating to apt.adafruit.com from apt.uniontownlabs.org"
-  sed -i 's/apt.uniontownlabs.org/apt.adafruit.com/g' /etc/apt/sources.list
+  sed -i '/apt.uniontownlabs.org/apt.adafruit.com/d' /etc/apt/sources.list
+  echo "deb http://apt.adafruit.com/raspbian/ wheezy main" >> /etc/apt/sources.list
   wget -O - -q https://apt.adafruit.com/apt.adafruit.com.gpg.key | apt-key add -
 fi

--- a/packages/occidentalis/DEBIAN/postinst
+++ b/packages/occidentalis/DEBIAN/postinst
@@ -34,3 +34,10 @@ if ! grep -Fq "pihome" /etc/samba/smb.conf; then
 EOF
   service samba restart
 fi
+
+# Migrate from apt.uniontownlabs.org to apt.adafruit.com
+if grep -q 'apt.uniontownlabs.org' /etc/apt/sources.list; then
+  echo "Migrating to apt.adafruit.com from apt.uniontownlabs.org"
+  sed -i 's/apt.uniontownlabs.org/apt.adafruit.com/g' /etc/apt/sources.list
+  wget -O - -q https://apt.adafruit.com/apt.adafruit.com.gpg.key | apt-key add -
+fi


### PR DESCRIPTION
Tweaks `postinst` to handle anybody who's still pointed at apt.uniontownlabs.org.  This feels a little dirty, but in context doesn't seem too evil.

@toddtreece check me on this one?